### PR TITLE
Add demo GIF workflow and tighten README

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -1,0 +1,49 @@
+name: Demo GIF
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  render-demo:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install ffmpeg
+        shell: pwsh
+        run: choco install ffmpeg -y --no-progress
+
+      - name: Install VHS
+        shell: pwsh
+        run: |
+          go install github.com/charmbracelet/vhs@v0.11.0
+          echo "$((go env GOPATH))\bin" >> $env:GITHUB_PATH
+
+      - name: Build WinTUI
+        shell: pwsh
+        run: go build -o wintui.exe .
+
+      - name: Validate tape
+        shell: pwsh
+        run: vhs validate demo.tape
+
+      - name: Render GIF
+        shell: pwsh
+        run: vhs demo.tape
+
+      - name: Upload demo artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-gif
+          path: demo.gif
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -2,70 +2,63 @@
 
 A terminal user interface for **winget** (Windows Package Manager), built with Go and the [Charmbracelet](https://charm.sh) TUI libraries.
 
-```
-██╗    ██╗ ██╗ ███╗   ██╗ ████████╗ ██╗   ██╗ ██╗
-██║    ██║ ██║ ████╗  ██║ ╚══██╔══╝ ██║   ██║ ██║
-██║ █╗ ██║ ██║ ██╔██╗ ██║    ██║    ██║   ██║ ██║
-██║███╗██║ ██║ ██║╚██╗██║    ██║    ██║   ██║ ██║
-╚███╔███╔╝ ██║ ██║ ╚████║    ██║    ╚██████╔╝ ██║
- ╚══╝╚══╝  ╚═╝ ╚═╝  ╚═══╝    ╚═╝     ╚═════╝  ╚═╝
-```
-
-## Features
-
-**Package Management**
-- **Upgrade** — scan for updates, upgrade all or select individual packages, what-if preview
-- **Installed** — browse installed packages across `winget`, `msstore`, and system entries, select and uninstall with `[X]` checkboxes
-- **Install** — search and install new packages with live streaming output and source-aware results
-- **Package Details** — view publisher, description, license, release notes, homepage (press `i`)
-- **Export / Restore** — export selected or installed packages to JSON and restore from Desktop exports with review before install
-
-**System Utilities**
-- **Health Check** — native Go checks for shells, dev tools, runtimes, package managers, disk space, Windows Defender, developer mode
-- **Temp Cleanup** — scan and delete temp files older than 7 days
-- **Settings** — persistent config for winget options (scope, architecture, silent/interactive, force, purge, etc.)
-
-**UX**
-- Tab-based navigation (click, number keys `1-6`, or `Tab`/`Shift+Tab` to cycle)
-- Per-tab screen state is preserved across tab switches
-- Fuzzy filter with `/` on package lists
-- Mouse support (tab clicks, table navigation, scroll)
-- Gradient progress bars (pink → mint) on all loading/executing states
-- Package cache with 2-minute TTL (`r` to force refresh)
-- Cancellable operations (`Esc` during loading)
-- Export selected packages to JSON with `e` (or all installed when nothing is selected) and restore from export with `m`
-- Dynamic context-aware help bar
-- `q` to quit
+Browse, install, upgrade, and manage Windows packages without leaving the terminal.
 
 ## Install
 
-**Requirements:** Go 1.24.2+, Windows 10/11 with winget installed.
+**Requirements:** Windows 10/11 with winget installed.
 
 ```bash
-# Clone and build
+# Run a release binary
+.\wintui.exe
+
+# Or build/install with Go 1.24.2+
+go install github.com/kts982/wintui@latest
+
+# Or clone and build from source
 git clone https://github.com/kts982/wintui.git
 cd wintui
 go build -o wintui.exe .
-
-# Or install directly
-go install github.com/kts982/wintui@latest
 ```
 
-Release downloads are also published on GitHub Releases:
+Pre-built binaries are available on [GitHub Releases](https://github.com/kts982/wintui/releases) — both `.exe` and `.zip` for Windows amd64 and arm64:
 
 ```bash
 gh release download --repo kts982/wintui --pattern '*windows_amd64.exe'
 ```
 
-Release assets include both raw `.exe` files and `.zip` archives for Windows `amd64` and `arm64`.
+`winget` publishing is planned next, but is not available yet.
+
+## Features
+
+**Package Management**
+- **Upgrade** — scan for updates, upgrade all or select individual packages
+- **Installed** — browse packages across `winget`, `msstore`, and `system` sources with selectable checkboxes
+- **Install** — search and install new packages with live streaming output
+- **Package Details** — view publisher, description, license, release notes, homepage (`i`)
+- **Export / Import** — export installed packages to JSON (`e`) and restore on another machine (`m`)
+
+**System Utilities**
+- **Health Check** — shells, dev tools, runtimes, package managers, disk space, Defender, developer mode
+- **Temp Cleanup** — scan and delete temp files older than 7 days
+- **Settings** — persistent config for winget options (scope, architecture, silent/interactive, force, purge, etc.)
+
+**UX**
+- Tab-based navigation with number keys, `Tab`/`Shift+Tab`, or mouse clicks
+- Per-tab screen state preserved across tab switches
+- Fuzzy filter (`/`) on package lists
+- Gradient progress bars on all loading states
+- Cancellable operations (`Esc`)
+- `Ctrl+e` to retry with admin elevation when needed
+- Context-aware help bar
 
 ## Usage
 
 ```bash
-./wintui.exe
+.\wintui.exe
 ```
 
-> **Tip:** Some packages (e.g. MSIX/Appx installers) require administrator privileges to upgrade. Run wintui in an elevated terminal for full functionality, or press `Ctrl+e` when WinTUI offers an elevated retry. The app shows a `● admin` / `● user` indicator in the tab bar and flags this in the Health Check.
+> **Tip:** Some operations require administrator privileges. Run in an elevated terminal for full functionality, or press `Ctrl+e` when WinTUI offers an elevated retry. The tab bar shows `● admin` / `● user` status.
 
 ## Keyboard Shortcuts
 
@@ -80,61 +73,58 @@ Release assets include both raw `.exe` files and `.zip` archives for Windows `am
 | `i` | Package details |
 | `o` | Open homepage (in detail view) |
 | `r` | Refresh data |
-| `Ctrl+e` | Retry current action elevated (when offered) |
+| `Ctrl+e` | Retry elevated (when offered) |
 | `e` | Export packages (Installed tab) |
-| `m` | Import packages from export JSON (Installed tab) |
+| `m` | Import from export JSON (Installed tab) |
 | `u` | Uninstall selected (Installed tab) |
 | `Esc` | Cancel / back |
 | `q` | Quit |
 
 ## Settings
 
-Settings are stored in `%APPDATA%\wintui\settings.json` and configurable from the Settings tab:
+Configurable from the Settings tab, stored in `%APPDATA%\wintui\settings.json`:
 
-- **Install Scope** — user / machine / auto
-- **Install Mode** — auto / silent / interactive
-- **Architecture** — x64 / x86 / arm64 / auto
-- **Default Source** — winget / msstore / auto
-- `Default Source` controls install/search preference; the Installed tab reflects the real installed state
-- **Force** — skip non-security issues
-- **Allow Reboot** — permit reboots during install
-- **Skip Dependencies** — don't process dependencies
-- **Purge on Uninstall** — delete all package files
-- **Include Unknown** — show packages with unknown versions
+| Setting | Options |
+|---|---|
+| Install Scope | user / machine / auto |
+| Install Mode | auto / silent / interactive |
+| Architecture | x64 / x86 / arm64 / auto |
+| Default Source | winget / msstore / auto |
+| Force | skip non-security issues |
+| Allow Reboot | permit reboots during install |
+| Skip Dependencies | don't process dependencies |
+| Purge on Uninstall | delete all package files |
+| Include Unknown | show packages with unknown versions |
+
+`Default Source` controls install/search preference; the Installed tab reflects the real installed state.
 
 ## Development
 
-Run the full local validation suite before pushing:
-
 ```powershell
+# Run the full validation suite
 .\scripts\check.ps1 -Mode full
-```
 
-This checks:
-- `gofmt`
-- `go test ./...`
-- `go vet ./...`
-- `staticcheck ./...`
-- `go build .`
-
-Optional Git hooks are included in `.githooks/pre-commit` and `.githooks/pre-push`. To enable them:
-
-```powershell
+# Optional: enable git hooks
 git config core.hooksPath .githooks
 ```
 
-Recommended workflow:
-- `pre-commit` stays fast and only checks formatting on staged Go files
-- `pre-push` runs the full validation suite
+The validation suite runs `gofmt`, `go test`, `go vet`, `staticcheck`, and `go build`.
+
+Optional Git hooks are included in `.githooks/pre-commit` and `.githooks/pre-push`.
+
+To regenerate the demo GIF, use the manual `Demo GIF` GitHub Actions workflow or render locally with [VHS](https://github.com/charmbracelet/vhs):
+
+```bash
+vhs demo.tape
+```
 
 ## Built With
 
 - [Bubble Tea](https://github.com/charmbracelet/bubbletea) — TUI framework
-- [Bubbles](https://github.com/charmbracelet/bubbles) — TUI components (table, spinner, progress, textinput, viewport, help)
+- [Bubbles](https://github.com/charmbracelet/bubbles) — TUI components
 - [Lip Gloss](https://github.com/charmbracelet/lipgloss) — Terminal styling
 - [Harmonica](https://github.com/charmbracelet/harmonica) — Spring-physics animations
 
 ## License
 
 MIT
-

--- a/demo.tape
+++ b/demo.tape
@@ -1,0 +1,110 @@
+# WinTUI Demo — run with: vhs demo.tape
+#
+# Prerequisites:
+#   - Windows 10/11 with winget
+#   - ffmpeg installed and available on PATH
+#   - VHS installed (go install github.com/charmbracelet/vhs@latest)
+#   - wintui.exe built in the repo root
+#
+# Timing notes:
+#   Adjust Sleep values if winget responses are slower on your machine.
+#   The first winget call after a reboot can take 5-10s to initialize sources.
+
+Output demo.gif
+Require winget
+Require ffmpeg
+
+Set Shell "powershell"
+Set FontSize 14
+Set Width 1200
+Set Height 650
+Set TypingSpeed 60ms
+Set Padding 15
+Set Framerate 24
+Set PlaybackSpeed 1.25
+
+# ── Build and launch ────────────────────────────────────────────────
+
+Hide
+Type "clear"
+Enter
+Show
+
+Type ".\\wintui.exe"
+Enter
+Sleep 5s
+
+# ── Upgrade tab (loaded automatically) ──────────────────────────────
+
+Down
+Sleep 400ms
+Up
+Sleep 600ms
+
+# ── Installed tab ───────────────────────────────────────────────────
+
+Type "2"
+Sleep 3s
+
+Down@150ms 4
+Sleep 500ms
+
+# Fuzzy filter for Firefox
+Type "/"
+Sleep 400ms
+Type "firefox"
+Sleep 1s
+Enter
+Sleep 800ms
+
+# Package details
+Type "i"
+Sleep 3s
+Escape
+Sleep 500ms
+
+# Clear filter
+Escape
+Sleep 800ms
+
+# ── Install tab ─────────────────────────────────────────────────────
+
+Type "3"
+Sleep 500ms
+
+Type "neovim"
+Enter
+Sleep 4s
+
+Down@300ms 2
+Up
+Sleep 500ms
+
+# Package details
+Type "i"
+Sleep 3s
+Escape
+Sleep 500ms
+
+# Back to search
+Escape
+Sleep 500ms
+
+# ── Health Check tab ────────────────────────────────────────────────
+
+Type "5"
+Sleep 4s
+
+Down@300ms 3
+Sleep 1s
+
+# ── Settings tab ────────────────────────────────────────────────────
+
+Type "6"
+Sleep 2s
+Down@300ms 2
+Sleep 500ms
+
+# ── Quit ────────────────────────────────────────────────────────────
+
+Ctrl+C


### PR DESCRIPTION
## Summary
- add a manual Windows GitHub Actions workflow to render demo.tape and upload demo.gif
- track demo.tape in the repo and clean up the README so it no longer advertises unavailable winget installation or a missing demo.gif
- keep the useful install/build/dev instructions while removing stale or misleading bits

## Validation
- powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check.ps1 -Mode full
- vhs validate demo.tape
