### PR TITLE
Install ttyd for demo GIF workflow

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -23,6 +23,10 @@ jobs:
         shell: pwsh
         run: choco install ffmpeg -y --no-progress
 
+      - name: Install ttyd
+        shell: pwsh
+        run: winget install --id tsl0922.ttyd --exact --accept-package-agreements --accept-source-agreements --disable-interactivity
+
       - name: Install VHS
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- install ttyd on the Windows runner before rendering the tape
- keep the existing ffmpeg, VHS, and build steps unchanged

## Validation
- existing workflow failure log showed 	tyd is not installed
- local repo validation passed during push via pre-push hook