### PR TITLE
Fix ttyd PATH in demo GIF workflow

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -25,7 +25,15 @@ jobs:
 
       - name: Install ttyd
         shell: pwsh
-        run: winget install --id tsl0922.ttyd --exact --accept-package-agreements --accept-source-agreements --disable-interactivity
+        run: |
+          winget install --id tsl0922.ttyd --exact --accept-package-agreements --accept-source-agreements --disable-interactivity
+          "$env:LOCALAPPDATA\Microsoft\WinGet\Links" >> $env:GITHUB_PATH
+
+      - name: Verify ttyd
+        shell: pwsh
+        run: |
+          Get-Command ttyd
+          ttyd --version
 
       - name: Install VHS
         shell: pwsh


### PR DESCRIPTION
## Summary
- add the WinGet links directory to PATH after installing ttyd
- verify ttyd is actually resolvable before running VHS

## Why
The previous run installed ttyd successfully, but VHS still failed with 	tyd is not installed because the current runner shell did not pick up the new WinGet alias path automatically.

## Validation
- repo validation passed during push via pre-push hook
- failing workflow logs confirmed the PATH issue