### PR TITLE
Prepare portable winget package for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pre-built binaries are available on [GitHub Releases](https://github.com/kts982/
 gh release download --repo kts982/wintui --pattern '*windows_amd64.exe'
 ```
 
-`winget` publishing is planned next, but is not available yet.
+Portable `winget` manifest files now live under [`packaging/winget`](./packaging/winget), and submission to the community `winget-pkgs` repository is the next distribution step.
 
 ## Features
 
@@ -120,6 +120,7 @@ The validation suite runs `gofmt`, `go test`, `go vet`, `staticcheck`, and `go b
 Optional Git hooks are included in `.githooks/pre-commit` and `.githooks/pre-push`.
 
 Maintainers can regenerate `demo.gif` from `demo.cast` with `agg`.
+Maintainers can validate the local WinGet manifest with `winget validate .\packaging\winget\manifests\k\kts982\WinTUI\0.1.0`.
 
 ## Built With
 

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,27 @@
+## WinGet Manifest
+
+This folder contains the local WinGet manifest set for the current GitHub release.
+
+Layout mirrors the `winget-pkgs` repository so the files can be validated locally and
+submitted with minimal reshaping.
+
+### Validate
+
+```powershell
+winget validate .\packaging\winget\manifests\k\kts982\WinTUI\0.1.0
+```
+
+### Test with a local manifest
+
+Local manifest installs must be enabled in WinGet settings before testing:
+
+```powershell
+winget settings --enable LocalManifestFiles
+winget install --manifest .\packaging\winget\manifests\k\kts982\WinTUI\0.1.0
+```
+
+### Submit
+
+1. Copy the manifest directory into a fork of `microsoft/winget-pkgs`.
+2. Run `winget validate` against the copied package-version directory.
+3. Open a PR to `microsoft/winget-pkgs`.

--- a/packaging/winget/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.installer.yaml
+++ b/packaging/winget/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - wintui
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v0.1.0/wintui_0.1.0_windows_amd64.exe
+    InstallerSha256: 1C77B7069BF3F4C56186D71E90018C8988642990DE2138CE7D4EA20EDC98568F
+  - Architecture: arm64
+    InstallerUrl: https://github.com/kts982/wintui/releases/download/v0.1.0/wintui_0.1.0_windows_arm64.exe
+    InstallerSha256: D1407944A853BBF53D147F0D518BD769E0C76169A3D96D49FCD89438E5C0B7A6
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.locale.en-US.yaml
+++ b/packaging/winget/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: kts982
+PublisherUrl: https://github.com/kts982
+PublisherSupportUrl: https://github.com/kts982/wintui/issues
+Author: Kostas T.
+PackageName: WinTUI
+PackageUrl: https://github.com/kts982/wintui
+License: MIT
+LicenseUrl: https://github.com/kts982/wintui/blob/main/LICENSE
+ShortDescription: Terminal UI for winget on Windows.
+Description: >-
+  WinTUI is a terminal user interface for Windows Package Manager. It lets you
+  browse installed packages, search package sources, install and upgrade
+  packages, export and restore package selections, and run a few workstation
+  utility tasks without leaving the terminal.
+Moniker: wintui
+Tags:
+  - winget
+  - windows
+  - tui
+  - terminal
+  - package-manager
+ReleaseNotesUrl: https://github.com/kts982/wintui/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.yaml
+++ b/packaging/winget/manifests/k/kts982/WinTUI/0.1.0/kts982.WinTUI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: kts982.WinTUI
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- add a local portable winget manifest set for kts982.WinTUI mirroring winget-pkgs
- point the manifest at the published 0.1.0 GitHub release assets and command alias
- document local validation and submission steps, and update the README install note

## Validation
- powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check.ps1 -Mode full
- winget validate .\\packaging\\winget\\manifests\\k\\kts982\\WinTUI\\0.1.0